### PR TITLE
Modify api to return object instead of array

### DIFF
--- a/javascript-client/src/api/DefaultApi.js
+++ b/javascript-client/src/api/DefaultApi.js
@@ -92,7 +92,7 @@
       var authNames = [];
       var contentTypes = [];
       var accepts = ['application/xml', 'application/json'];
-      var returnType = [TreatmentOptions];
+      var returnType = {TreatmentOptions};
 
       
       return this.apiClient.callApi(


### PR DESCRIPTION
JIRA 1323 

update api return type of findPatientsbyStats to be object instead of array

To test:
in the /javascript-client directory run 
npm link 

In the /Flux directory run
npm link <path to treatment-options-javascript-client/javascript-client>

This should update the flux project to use the new client